### PR TITLE
Added `--output` option to export benchmark results to a CSV file.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tcpkali2"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 description = "A load testing tool for WebSocket and TCP server."
 authors = ["limpo1989 <limpo1989@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   -f, --message-file <name>          Read message to send from a file
   -r, --message-rate <R>             Messages per second to send in a connection
   -q                                 Suppress real-time output
+  -o, --output <FILE>                Export final results to a CSV file
   -h, --help                         Print help
   -V, --version                      Print version
 ```

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,7 @@
 use crate::error::TcpKaliError;
 use crate::utils::{generate_payload, get_file_arg, get_message_arg, parse_duration, parse_rate};
 use bytes::Bytes;
-use clap::{Arg, ArgAction, Command, value_parser};
+use clap::{value_parser, Arg, ArgAction, Command};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -38,6 +38,8 @@ pub struct Config {
     pub message_rate: Option<u64>,
     /// Whether WebSocket is used
     pub use_websocket: bool,
+    /// Output CSV file path
+    pub output: Option<String>,
 }
 
 /// Parse command line arguments and create configuration
@@ -70,21 +72,30 @@ pub fn parse_config(matches: &clap::ArgMatches) -> Result<Arc<Config>, TcpKaliEr
         message_size,
         message_rate: matches.get_one::<u64>("message-rate").cloned(),
         use_websocket: matches.get_flag("websocket"),
+        output: matches.get_one::<String>("output").cloned(),
     };
 
     // Parameter validation
     if config.connections == 0 {
-        return Err(TcpKaliError::Config("connections must be greater than 0".into()));
+        return Err(TcpKaliError::Config(
+            "connections must be greater than 0".into(),
+        ));
     }
     if config.connect_timeout.as_secs_f64() == 0.0 {
-        return Err(TcpKaliError::Config("connect-timeout must be greater than 0".into()));
+        return Err(TcpKaliError::Config(
+            "connect-timeout must be greater than 0".into(),
+        ));
     }
     if config.duration.as_secs_f64() == 0.0 {
-        return Err(TcpKaliError::Config("duration must be greater than 0".into()));
+        return Err(TcpKaliError::Config(
+            "duration must be greater than 0".into(),
+        ));
     }
     if let Some(lifetime) = config.channel_lifetime {
         if lifetime.as_secs_f64() == 0.0 {
-            return Err(TcpKaliError::Config("channel-lifetime must be greater than 0 if specified".into()));
+            return Err(TcpKaliError::Config(
+                "channel-lifetime must be greater than 0 if specified".into(),
+            ));
         }
     }
 
@@ -97,7 +108,7 @@ pub fn parse_config(matches: &clap::ArgMatches) -> Result<Arc<Config>, TcpKaliEr
 /// * `clap::ArgMatches` - Parsed command line arguments
 pub fn new_command() -> clap::ArgMatches {
     Command::new("tcpkali2")
-        .version(env!("CARGO_PKG_VERSION") )
+        .version(env!("CARGO_PKG_VERSION"))
         .about("A load testing tool for WebSocket and TCP server")
         .arg(
             Arg::new("host:port")
@@ -237,6 +248,13 @@ pub fn new_command() -> clap::ArgMatches {
                 .short('q')
                 .action(ArgAction::SetTrue)
                 .help("Suppress real-time output"),
+        )
+        .arg(
+            Arg::new("output")
+                .short('o')
+                .long("output")
+                .value_name("FILE")
+                .help("Export final results to a CSV file"),
         )
         .get_matches()
 }

--- a/src/csv_export.rs
+++ b/src/csv_export.rs
@@ -1,0 +1,226 @@
+use crate::command::Config;
+use crate::stats::Stats;
+use std::fs;
+use std::io::{BufRead, Write};
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+/// All CSV column headers in a fixed order.
+const HEADERS: &[&str] = &[
+    "timestamp",
+    "target",
+    "connections",
+    "connect_rate",
+    "connect_timeout_s",
+    "channel_lifetime_s",
+    "duration_s",
+    "warmup_s",
+    "workers",
+    "nagle",
+    "pipeline",
+    "websocket",
+    "message_size",
+    "message_rate",
+    "total_connections",
+    "success_rate_pct",
+    "total_requests",
+    "error_rate_pct",
+    "requests_per_sec",
+    "throughput_mb",
+    "bandwidth_mb_s",
+    "traffic_down_mbps",
+    "traffic_up_mbps",
+    "latency_avg_us",
+    "latency_min_us",
+    "latency_p50_us",
+    "latency_p90_us",
+    "latency_p95_us",
+    "latency_p99_us",
+    "latency_max_us",
+];
+
+/// Build the header line from the fixed column list.
+fn header_line() -> String {
+    HEADERS.join(",")
+}
+
+/// Build a data row from config and stats.
+fn build_row(
+    config: &Config,
+    stats: &Stats,
+    duration: Duration,
+    target: &str,
+    workers: usize,
+) -> String {
+    let hist = stats.latency_histogram.lock();
+    let total_bytes_sent = stats.total_bytes_sent.load(Ordering::Relaxed);
+    let total_bytes_received = stats.total_bytes_received.load(Ordering::Relaxed);
+    let total_bytes = total_bytes_sent + total_bytes_received;
+    let total_requests = stats.total_requests.load(Ordering::Relaxed);
+    let elapsed = duration.as_secs_f64();
+
+    let qps = if elapsed > 0.0 {
+        total_requests as f64 / elapsed
+    } else {
+        0.0
+    };
+
+    let total_connections = stats.total_connections.load(Ordering::Relaxed) as f64;
+    let success_connections = stats.success_connections.load(Ordering::Relaxed) as f64;
+    let success_rate = if total_connections > 0.0 {
+        success_connections / total_connections * 100.0
+    } else {
+        0.0
+    };
+
+    let error_rate = if total_requests > 0 {
+        stats.connection_errors.load(Ordering::Relaxed) as f64 / (total_requests as f64 * 100.0)
+    } else {
+        0.0
+    };
+
+    let bandwidth = if elapsed > 0.0 {
+        total_bytes as f64 / elapsed / 1_000_000.0
+    } else {
+        0.0
+    };
+
+    // Get current UTC timestamp in RFC 3339 format without external crate
+    let timestamp = {
+        let d = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+        let secs = d.as_secs();
+        // Convert epoch seconds to date-time components
+        let (year, month, day, hour, min, sec) = epoch_to_datetime(secs);
+        format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+            year, month, day, hour, min, sec
+        )
+    };
+
+    let channel_lifetime_str = config
+        .channel_lifetime
+        .map(|d| format!("{:.2}", d.as_secs_f64()))
+        .unwrap_or_else(|| "-1".to_string());
+
+    let message_rate_str = config
+        .message_rate
+        .map(|r| r.to_string())
+        .unwrap_or_else(|| "-1".to_string());
+
+    let values: Vec<String> = vec![
+        timestamp,
+        target.to_string(),
+        config.connections.to_string(),
+        config.connect_rate.to_string(),
+        format!("{:.2}", config.connect_timeout.as_secs_f64()),
+        channel_lifetime_str,
+        format!("{:.2}", config.duration.as_secs_f64()),
+        format!("{:.2}", config.warmup_duration.as_secs_f64()),
+        workers.to_string(),
+        config.nagle.to_string(),
+        config.pipeline.to_string(),
+        config.use_websocket.to_string(),
+        config.message_size.to_string(),
+        message_rate_str,
+        format!("{}", total_connections),
+        format!("{:.1}", success_rate),
+        total_requests.to_string(),
+        format!("{:.2}", error_rate),
+        format!("{:.2}", qps),
+        format!("{:.2}", total_bytes as f64 / 1_000_000.0),
+        format!("{:.2}", bandwidth),
+        format!("{:.2}", total_bytes_received * 8 / 1_000_000),
+        format!("{:.2}", total_bytes_sent * 8 / 1_000_000),
+        format!("{:.1}", hist.mean()),
+        format!("{}", hist.min()),
+        format!("{}", hist.value_at_percentile(50.0)),
+        format!("{}", hist.value_at_percentile(90.0)),
+        format!("{}", hist.value_at_percentile(95.0)),
+        format!("{}", hist.value_at_percentile(99.0)),
+        format!("{}", hist.max()),
+    ];
+
+    values.join(",")
+}
+
+/// Convert epoch seconds (UTC) to (year, month, day, hour, minute, second).
+fn epoch_to_datetime(epoch: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let sec = epoch % 60;
+    let min = (epoch / 60) % 60;
+    let hour = (epoch / 3600) % 24;
+    let mut days = epoch / 86400;
+
+    // Calculate year
+    let mut year = 1970u64;
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    // Calculate month and day
+    let days_in_months: [u64; 12] = if is_leap(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    let mut month = 0u64;
+    for (i, &dim) in days_in_months.iter().enumerate() {
+        if days < dim {
+            month = i as u64 + 1;
+            break;
+        }
+        days -= dim;
+    }
+    let day = days + 1;
+
+    (year, month, day, hour, min, sec)
+}
+
+fn is_leap(year: u64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}
+
+/// Export benchmark results to a CSV file.
+///
+/// - If the file does not exist, creates it with headers + data row.
+/// - If it exists and headers match, appends the data row.
+/// - If it exists but headers don't match, silently overwrites with correct headers + data row.
+pub fn export_csv(
+    path: &str,
+    config: &Config,
+    stats: &Stats,
+    duration: Duration,
+    target: &str,
+    workers: usize,
+) {
+    let expected_header = header_line();
+    let row = build_row(config, stats, duration, target, workers);
+
+    if let Ok(file) = fs::File::open(path) {
+        // File exists — check if headers match
+        let reader = std::io::BufReader::new(file);
+        if let Some(Ok(first_line)) = reader.lines().next() {
+            if first_line.trim() == expected_header {
+                // Headers match — append
+                if let Ok(mut f) = fs::OpenOptions::new().append(true).open(path) {
+                    let _ = writeln!(f, "{}", row);
+                    return;
+                }
+            }
+        }
+        // Headers don't match or couldn't read — fall through to overwrite
+    }
+
+    // Create / overwrite
+    if let Ok(mut f) = fs::File::create(path) {
+        let _ = writeln!(f, "{}", expected_header);
+        let _ = writeln!(f, "{}", row);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod command;
+mod csv_export;
 mod error;
 mod runner;
 mod stats;
@@ -18,7 +19,9 @@ fn main() -> Result<(), TcpKaliError> {
     let matches = new_command();
     let workers = *matches.get_one::<usize>("workers").unwrap();
     if workers == 0 {
-        return Err(TcpKaliError::Config("workers must be greater than 0".into()));
+        return Err(TcpKaliError::Config(
+            "workers must be greater than 0".into(),
+        ));
     }
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(workers)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -26,6 +26,13 @@ pub async fn async_main(matches: clap::ArgMatches) -> Result<(), TcpKaliError> {
     let config = crate::command::parse_config(&matches)?;
     let stats = Arc::new(Stats::new());
     let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+    let workers = *matches.get_one::<usize>("workers").unwrap();
+    // Collect targets for CSV export (use first target for the CSV row)
+    let targets: Vec<String> = matches
+        .get_many::<String>("host:port")
+        .unwrap()
+        .cloned()
+        .collect();
 
     // Periodically output real-time statistics
     if !config.quiet {
@@ -42,7 +49,7 @@ pub async fn async_main(matches: clap::ArgMatches) -> Result<(), TcpKaliError> {
     };
 
     // Prepare tasks
-    for target in matches.get_many::<String>("host:port").unwrap() {
+    for target in targets.iter() {
         for i in 0..config.connections {
             let task_config = config.clone();
             let task_stats = stats.clone();
@@ -75,8 +82,17 @@ pub async fn async_main(matches: clap::ArgMatches) -> Result<(), TcpKaliError> {
     // Execute benchmark
     execute_benchmark(&config, &stats, &shutdown_tx, &mut tasks).await;
 
+    let elapsed = start_time.elapsed();
+
     // Output statistical results
-    Stats::print_final_stats(&stats, start_time.elapsed(), !config.quiet);
+    Stats::print_final_stats(&stats, elapsed, !config.quiet);
+
+    // Export to CSV if --output is specified
+    if let Some(ref path) = config.output {
+        let target = targets.first().map(|s| s.as_str()).unwrap_or("");
+        crate::csv_export::export_csv(path, &config, &stats, elapsed, target, workers);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Add a new `--output` / `-o` CLI option to export final benchmark results to a CSV file, making it easy to track and compare benchmark runs over time.

## Motivation

After each benchmark run, users have to manually copy individual fields from the console output and enter them into a spreadsheet, document, or tracking system. This is repetitive, error-prone (easy to misread or misplace a value), and doesn't scale when running multiple benchmarks with different configurations. 

This feature eliminates that manual work entirely — results are automatically written to a structured CSV file with both the run configuration and output metrics in a single row, ready to use as-is.

## Use Cases

- **Performance regression tracking** — Run benchmarks after each deploy or code change and append results to the same CSV. Spot regressions by comparing `requests_per_sec` and latency percentiles across runs.
- **Configuration tuning** — Experiment with different `--connections`, `--message-rate`, or `--workers` values and export each run to the same file. Since config columns are included alongside results, you can directly correlate settings with performance.
- **CI/CD integration** — Add `tcpkali2` to your pipeline with `-o benchmark_results.csv` and archive the CSV as a build artifact. Track performance trends over builds without any extra tooling.
- **Reporting & visualization** — Import the CSV into Excel, Google Sheets, Grafana, or any data tool to create charts and dashboards for latency distributions, throughput trends, etc.
- **Team collaboration** — Share a single CSV file with your team instead of pasting terminal screenshots. Everyone gets the same structured data to analyze.

## Usage

```bash
# Export results to a CSV file
tcpkali2 localhost:8080 -c 10 -T 15s --output results.csv

# Shorthand
tcpkali2 localhost:8080 -c 10 -T 15s -o results.csv
```

## CSV Format

The CSV contains 30 columns covering both run configuration and results:

**Config columns:** `timestamp`, `target`, `connections`, `connect_rate`, `connect_timeout_s`, `channel_lifetime_s`, `duration_s`, `warmup_s`, `workers`, `nagle`, `pipeline`, `websocket`, `message_size`, `message_rate`

**Result columns:** `total_connections`, `success_rate_pct`, `total_requests`, `error_rate_pct`, `requests_per_sec`, `throughput_mb`, `bandwidth_mb_s`, `traffic_down_mbps`, `traffic_up_mbps`, `latency_avg_us`, `latency_min_us`, `latency_p50_us`, `latency_p90_us`, `latency_p95_us`, `latency_p99_us`, `latency_max_us`

## File Handling Behavior

| Scenario | Action |
|----------|--------|
| File does not exist | Create with headers + data row |
| File exists, headers match | Append data row |
| File exists, headers mismatch | Overwrite with correct headers + data row |

## Changes

- **`src/csv_export.rs`** (new) — CSV export logic with fixed column order
- **`src/command.rs`** — Added `--output`/`-o` arg and `output` field to `Config`
- **`src/runner.rs`** — Calls CSV export after `print_final_stats` when flag is set
- **`src/main.rs`** — Registered new module
- **`Cargo.toml`** — Version bump to `0.2.0`

## Notes

- No new crate dependencies added — uses manual CSV formatting
- Optional fields (`channel_lifetime`, `message_rate`) default to `-1` when not specified
- Timestamp is UTC in RFC 3339 format
